### PR TITLE
Fix for allowing checksums to be disabled

### DIFF
--- a/src/main/resources/META-INF/resources/raptor_modules/optimizer/BundlesWriter.js
+++ b/src/main/resources/META-INF/resources/raptor_modules/optimizer/BundlesWriter.js
@@ -216,7 +216,7 @@ raptor.defineClass(
                 
                 var checksum;
                 
-                if (this.checksumsEnabled !== false || bundle.requireChecksum) {
+                if (this.config.checksumsEnabled !== false || bundle.requireChecksum) {
                     checksum = this.calculateChecksum(bundleCode);
                 }
                 


### PR DESCRIPTION
There was a bug in your code. You should have been reading checksumsEnabled from this.config.checksumsEnabled (not this.checksumsEnabled).
